### PR TITLE
reformat, tidy, add support for all Pointer, Vector, Array

### DIFF
--- a/tres.zig
+++ b/tres.zig
@@ -1,13 +1,40 @@
 const std = @import("std");
 
-pub const ParseOptions = struct {
-    suppress_error_logs: bool = true,
-    /// Allocator, needed for non-u8/std.json.Value arrays
-    allocator: ?std.mem.Allocator = null,
-};
+fn isHashMap(comptime T: type) bool {
+    if (!@hasDecl(T, "KV")) return false;
 
-pub fn parse(comptime T: type, tree: std.json.Value, options: ParseOptions) ParseInternalError(T)!T {
-    return try parseInternal(T, "root", @typeName(T), tree, options);
+    if (!@hasField(T.KV, "key")) return false;
+    if (!@hasField(T.KV, "value")) return false;
+
+    const Key = std.meta.fields(T.KV)[std.meta.fieldIndex(T.KV, "key") orelse unreachable].field_type;
+    const Value = std.meta.fields(T.KV)[std.meta.fieldIndex(T.KV, "value") orelse unreachable].field_type;
+
+    if (!@hasDecl(T, "init")) return false;
+    if (!@hasDecl(T, "put")) return false;
+
+    const init = @TypeOf(T.init);
+
+    if (init != fn (std.mem.Allocator) T) return false;
+
+    const put = @typeInfo(@TypeOf(T.put));
+
+    if (put != .Fn) return false;
+
+    if (put.Fn.args.len != 3) return false;
+    if (put.Fn.args[0].arg_type.? != *T) return false;
+    if (put.Fn.args[1].arg_type.? != Key) return false;
+    if (put.Fn.args[2].arg_type.? != Value) return false;
+    if (put.Fn.return_type == null) return false;
+
+    const put_return = @typeInfo(put.Fn.return_type.?);
+    if (put_return != .ErrorUnion) return false;
+    if (put_return.ErrorUnion.payload != void) return false;
+
+    return true;
+}
+
+pub fn parse(comptime T: type, tree: std.json.Value, allocator: ?std.mem.Allocator) ParseInternalError(T)!T {
+    return try parseInternal(T, "root", @typeName(T), tree, allocator, false);
 }
 
 pub fn Undefinedable(comptime T: type) type {
@@ -21,7 +48,13 @@ pub fn Undefinedable(comptime T: type) type {
 }
 
 pub fn ParseInternalError(comptime T: type) type {
-    if ((@typeInfo(T) == .Struct or @typeInfo(T) == .Enum or @typeInfo(T) == .Union) and @hasDecl(T, "tresParse")) {
+    // `inferred_types` is used to avoid infinite recursion for recursive type definitions.
+    const inferred_types = [_]type{};
+    return ParseInternalErrorImpl(T, &inferred_types);
+}
+
+fn ParseInternalErrorImpl(comptime T: type, comptime inferred_types: []const type) type {
+    if (comptime std.meta.trait.isContainer(T) and @hasDecl(T, "tresParse")) {
         const tresParse_return = @typeInfo(@typeInfo(@TypeOf(T.tresParse)).Fn.return_type.?);
         if (tresParse_return == .ErrorUnion) {
             return tresParse_return.ErrorUnion.error_set;
@@ -30,30 +63,24 @@ pub fn ParseInternalError(comptime T: type) type {
         }
     }
 
-    // `inferred_types` is used to avoid infinite recursion for recursive type definitions.
-    const inferred_types = [_]type{};
-    return ParseInternalErrorImpl(T, &inferred_types);
-}
-
-fn ParseInternalErrorImpl(comptime T: type, comptime inferred_types: []const type) type {
     for (inferred_types) |ty| {
         if (T == ty) return error{};
     }
 
+    const inferred_set = inferred_types ++ [_]type{T};
+
     switch (@typeInfo(T)) {
         .Bool, .Float => return error{UnexpectedFieldType},
-        .Pointer => |info| switch (info.child) {
-            u8, std.json.Value => return error{UnexpectedFieldType},
-            else => return error{ UnexpectedFieldType, OutOfMemory } || (if (info.child != std.json.Value) error{AllocatorRequired} else error{}) || ParseInternalErrorImpl(info.child, inferred_types ++ [_]type{T}),
-        },
-        .Optional => |info| return ParseInternalErrorImpl(info.child, inferred_types ++ [_]type{T}),
-        .Enum => return error{ InvalidEnumTag, UnexpectedFieldType },
         .Int => return error{ UnexpectedFieldType, Overflow },
+        .Optional => |info| return ParseInternalErrorImpl(info.child, inferred_set),
+        .Enum => return error{ InvalidEnumTag, UnexpectedFieldType },
         .Union => |info| {
             var errors = error{UnexpectedFieldType};
+
             for (info.fields) |field| {
-                errors = errors || ParseInternalErrorImpl(field.field_type, inferred_types ++ [_]type{T});
+                errors = errors || ParseInternalErrorImpl(field.field_type, inferred_set);
             }
+
             return errors;
         },
         .Struct => |info| {
@@ -62,78 +89,181 @@ fn ParseInternalErrorImpl(comptime T: type, comptime inferred_types: []const typ
                 InvalidFieldValue,
                 MissingRequiredField,
             };
-            if (@hasDecl(T, "KV") and std.meta.fields(T.KV)[1].field_type != std.json.Value) errors = errors || error{AllocatorRequired};
-            for (info.fields) |field| {
-                errors = errors || ParseInternalErrorImpl(field.field_type, inferred_types ++ [_]type{T});
+
+            if (isAllocatorRequired(T)) {
+                errors = errors || error{AllocatorRequired} || std.mem.Allocator.Error;
             }
+
+            for (info.fields) |field| {
+                errors = errors || ParseInternalErrorImpl(field.field_type, inferred_set);
+            }
+
             return errors;
         },
+        .Pointer => |info| {
+            var errors = error{UnexpectedFieldType};
+
+            if (isAllocatorRequired(T)) {
+                errors = errors || error{AllocatorRequired} || std.mem.Allocator.Error;
+            }
+
+            if (info.size == .Slice and info.child == u8 or info.child == std.json.Value)
+                return errors;
+
+            errors = errors || ParseInternalErrorImpl(info.child, inferred_set);
+
+            return errors;
+        },
+        .Array => |info| {
+            var errors = error{UnexpectedFieldType};
+
+            errors = errors || ParseInternalErrorImpl(info.child, inferred_set);
+
+            return errors;
+        },
+        .Vector => |info| {
+            var errors = error{UnexpectedFieldType};
+
+            errors = errors || ParseInternalErrorImpl(info.child, inferred_set);
+
+            return errors;
+        },
+
         else => return error{},
     }
 }
 
+pub fn isAllocatorRequired(comptime T: type) bool {
+    // `inferred_types` is used to avoid infinite recursion for recursive type definitions.
+    const inferred_types = [_]type{};
+    return isAllocatorRequiredImpl(T, &inferred_types);
+}
+
+fn isAllocatorRequiredImpl(comptime T: type, comptime inferred_types: []const type) bool {
+    for (inferred_types) |ty| {
+        if (T == ty) return false;
+    }
+
+    const inferred_set = inferred_types ++ [_]type{T};
+
+    switch (@typeInfo(T)) {
+        .Optional => |info| return isAllocatorRequiredImpl(info.child, inferred_set),
+        .Union => |info| {
+            for (info.fields) |field| {
+                if (isAllocatorRequiredImpl(field.field_type, inferred_set))
+                    return true;
+            }
+        },
+        .Struct => |info| {
+            if (isHashMap(T)) {
+                if (T == std.json.ObjectMap)
+                    return false;
+
+                return true;
+            }
+
+            for (info.fields) |field| {
+                if (@typeInfo(field.field_type) == .Struct and @hasDecl(field.field_type, "__json_is_undefinedable")) {
+                    if (isAllocatorRequiredImpl(field.field_type.__json_T, inferred_set))
+                        return true;
+                } else if (isAllocatorRequiredImpl(field.field_type, inferred_set))
+                    return true;
+            }
+        },
+        .Pointer => |info| {
+            if (info.size == .Slice and info.child == u8 or info.child == std.json.Value)
+                return false;
+
+            return true;
+        },
+        .Array => |info| {
+            return isAllocatorRequiredImpl(info.child, inferred_set);
+        },
+        .Vector => |info| {
+            return isAllocatorRequiredImpl(info.child, inferred_set); // is it even possible for this to be true?
+        },
+        else => {},
+    }
+
+    return false;
+}
+
 const logger = std.log.scoped(.json);
-fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime field_name: []const u8, value: std.json.Value, options: ParseOptions) ParseInternalError(T)!T {
+fn parseInternal(
+    comptime T: type,
+    comptime parent_name: []const u8,
+    comptime field_name: []const u8,
+    json_value: std.json.Value,
+    maybe_allocator: ?std.mem.Allocator,
+    comptime suppress_error_logs: bool,
+) ParseInternalError(T)!T {
     const name = parent_name ++ "." ++ field_name;
 
-    if (T == std.json.Value) return value;
-    if ((@typeInfo(T) == .Struct or @typeInfo(T) == .Enum or @typeInfo(T) == .Union) and @hasDecl(T, "tresParse")) {
-        return T.tresParse(value, options);
+    if (T == std.json.Value) return json_value;
+    if (comptime std.meta.trait.isContainer(T) and @hasDecl(T, "tresParse")) {
+        return T.tresParse(json_value, maybe_allocator);
     }
 
     switch (@typeInfo(T)) {
         .Bool => {
-            if (value == .Bool) {
-                return value.Bool;
+            if (json_value == .Bool) {
+                return json_value.Bool;
             } else {
-                if (!options.suppress_error_logs) logger.err("expected Bool, found {s} at {s}", .{ @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("expected Bool, found {s} at {s}", .{ @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             }
         },
         .Float => {
-            if (value == .Float) {
-                return @floatCast(T, value.Float);
+            if (json_value == .Float) {
+                return @floatCast(T, json_value.Float);
             } else {
-                if (!options.suppress_error_logs) logger.err("expected Float, found {s} at {s}", .{ @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("expected Float, found {s} at {s}", .{ @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             }
         },
         .Int => {
-            if (value == .Integer) {
-                return try std.math.cast(T, value.Integer);
+            if (json_value == .Integer) {
+                return std.math.cast(T, json_value.Integer) orelse return error.Overflow;
             } else {
-                if (!options.suppress_error_logs) logger.err("expected Integer, found {s} at {s}", .{ @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("expected Integer, found {s} at {s}", .{ @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             }
         },
         .Optional => |info| {
-            if (value == .Null) {
+            if (json_value == .Null) {
                 return null;
             } else {
-                return try parseInternal(info.child, name, "?", value, options);
+                return try parseInternal(
+                    info.child,
+                    name,
+                    "?",
+                    json_value,
+                    maybe_allocator,
+                    suppress_error_logs,
+                );
             }
         },
         .Enum => {
-            if (value == .Integer) {
+            if (json_value == .Integer) {
                 // we use this to convert signed to unsigned and check if it actually fits.
-                const tag = std.math.cast(std.meta.Tag(T), value.Integer) catch {
-                    if (!options.suppress_error_logs) logger.err("invalid enum tag for {s}, found {d} at {s}", .{ @typeName(T), value.Integer, name });
+                const tag = std.math.cast(std.meta.Tag(T), json_value.Integer) orelse {
+                    if (comptime !suppress_error_logs) logger.debug("invalid enum tag for {s}, found {d} at {s}", .{ @typeName(T), json_value.Integer, name });
 
                     return error.InvalidEnumTag;
                 };
 
                 return try std.meta.intToEnum(T, tag);
-            } else if (value == .String) {
-                return std.meta.stringToEnum(T, value.String) orelse {
-                    if (!options.suppress_error_logs) logger.err("invalid enum tag for {s}, found '{s}' at {s}", .{ @typeName(T), value.String, name });
+            } else if (json_value == .String) {
+                return std.meta.stringToEnum(T, json_value.String) orelse {
+                    if (comptime !suppress_error_logs) logger.debug("invalid enum tag for {s}, found '{s}' at {s}", .{ @typeName(T), json_value.String, name });
 
                     return error.InvalidEnumTag;
                 };
             } else {
-                if (!options.suppress_error_logs) logger.err("expected Integer or String, found {s} at {s}", .{ @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("expected Integer or String, found {s} at {s}", .{ @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             }
@@ -141,15 +271,19 @@ fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime fi
         .Union => |info| {
             if (info.tag_type != null) {
                 inline for (info.fields) |field| {
-                    var union_options = options;
-                    union_options.suppress_error_logs = true;
-
-                    if (parseInternal(field.field_type, @typeName(T), field.name, value, union_options)) |parsed_value| {
+                    if (parseInternal(
+                        field.field_type,
+                        name,
+                        field.name,
+                        json_value,
+                        maybe_allocator,
+                        true,
+                    )) |parsed_value| {
                         return @unionInit(T, field.name, parsed_value);
                     } else |_| {}
                 }
 
-                if (!options.suppress_error_logs) logger.err("union fell through for {s}, found {s} at {s}", .{ @typeName(T), @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("union fell through for {s}, found {s} at {s}", .{ @typeName(T), @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             } else {
@@ -157,37 +291,46 @@ fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime fi
             }
         },
         .Struct => |info| {
-            if (@hasDecl(T, "KV")) {
-                const Key = std.meta.fields(T.KV)[0].field_type;
-                const Value = std.meta.fields(T.KV)[1].field_type;
+            if (comptime isHashMap(T)) {
+                const Key = std.meta.fields(T.KV)[std.meta.fieldIndex(T.KV, "key") orelse unreachable].field_type;
+                const Value = std.meta.fields(T.KV)[std.meta.fieldIndex(T.KV, "value") orelse unreachable].field_type;
 
-                if (Key != []const u8) @compileError("ArrayHashMap key must be of type []const u8!");
+                if (Key != []const u8) @compileError("HashMap key must be of type []const u8!");
 
-                if (value == .Object) {
-                    if (Value == std.json.Value) return value.Object;
+                if (json_value == .Object) {
+                    if (T == std.json.ObjectMap) return json_value.Object;
 
-                    var map = T.init(options.allocator orelse return error.AllocatorRequired);
-                    var map_iterator = value.Object.iterator();
+                    const allocator = maybe_allocator orelse return error.AllocatorRequired;
+
+                    var map = T.init(allocator);
+                    var map_iterator = json_value.Object.iterator();
 
                     while (map_iterator.next()) |entry| {
-                        try map.put(entry.key_ptr.*, try parseInternal(Value, @typeName(T), ".entry", entry.value_ptr.*, options));
+                        try map.put(entry.key_ptr.*, try parseInternal(
+                            Value,
+                            name,
+                            ".(hashmap entry)",
+                            entry.value_ptr.*,
+                            maybe_allocator,
+                            suppress_error_logs,
+                        ));
                     }
 
                     return map;
                 } else {
-                    if (!options.suppress_error_logs) logger.err("expected map of {s} at {s}, found {s}", .{ @typeName(Value), name, @tagName(value) });
+                    if (comptime !suppress_error_logs) logger.debug("expected map of {s} at {s}, found {s}", .{ @typeName(Value), name, @tagName(json_value) });
                     return error.UnexpectedFieldType;
                 }
             }
 
             if (info.is_tuple) {
-                if (value != .Array) {
-                    if (!options.suppress_error_logs) logger.err("expected Array, found {s} at {s}", .{ @tagName(value), name });
+                if (json_value != .Array) {
+                    if (comptime !suppress_error_logs) logger.debug("expected Array, found {s} at {s}", .{ @tagName(json_value), name });
                     return error.UnexpectedFieldType;
                 }
 
-                if (value.Array.items.len != std.meta.fields(T).len) {
-                    if (!options.suppress_error_logs) logger.err("expected Array to match length of Tuple {s} but it doesn't; at {s}", .{ @typeName(T), name });
+                if (json_value.Array.items.len != std.meta.fields(T).len) {
+                    if (comptime !suppress_error_logs) logger.debug("expected Array to match length of Tuple {s} but it doesn't; at {s}", .{ @typeName(T), name });
                     return error.UnexpectedFieldType;
                 }
 
@@ -195,41 +338,77 @@ fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime fi
                 comptime var index: usize = 0;
 
                 inline while (index < std.meta.fields(T).len) : (index += 1) {
-                    tuple[index] = try parseInternal(std.meta.fields(T)[index].field_type, @typeName(T), comptime std.fmt.comptimePrint("{d}", .{index}), value.Array.items[index], options);
+                    tuple[index] = try parseInternal(
+                        std.meta.fields(T)[index].field_type,
+                        name,
+                        comptime std.fmt.comptimePrint("[{d}]", .{index}),
+                        json_value.Array.items[index],
+                        maybe_allocator,
+                        suppress_error_logs,
+                    );
                 }
 
                 return tuple;
             }
 
-            if (value == .Object) {
+            if (json_value == .Object) {
                 var result: T = undefined;
 
                 // Must use in order to bypass [#2727](https://github.com/ziglang/zig/issues/2727) :(
                 var missing_field = false;
 
                 inline for (info.fields) |field| {
-                    const field_value = value.Object.get(field.name);
+                    const field_value = json_value.Object.get(field.name);
 
                     if (field.is_comptime) {
                         if (field_value == null) {
-                            if (!options.suppress_error_logs) logger.err("comptime field {s}.{s} missing, at {s}", .{ @typeName(T), field.name, name });
+                            if (comptime !suppress_error_logs) logger.debug("comptime field {s}.{s} missing, at {s}", .{ @typeName(T), field.name, name });
 
                             return error.InvalidFieldValue;
                         }
 
-                        const parsed_value = try parseInternal(field.field_type, @typeName(T), field.name, field_value.?, options);
-                        // NOTE: This only works for strings!
-                        if (!std.mem.eql(u8, parsed_value, @ptrCast(*const field.field_type, field.default_value.?).*)) {
-                            if (!options.suppress_error_logs) logger.err("comptime field {s}.{s} does not match", .{ @typeName(T), field.name });
+                        if (field.default_value) |default| {
+                            const parsed_value = try parseInternal(
+                                field.field_type,
+                                name,
+                                field.name,
+                                field_value.?,
+                                maybe_allocator,
+                                suppress_error_logs,
+                            );
+                            const default_value = @ptrCast(*const field.field_type, default).*;
 
-                            return error.InvalidFieldValue;
-                        }
+                            // NOTE: This only works for strings!
+                            // TODODODODODODO ASAP
+                            if (!std.mem.eql(u8, parsed_value, default_value)) {
+                                if (comptime !suppress_error_logs) logger.debug("comptime field {s}.{s} does not match", .{ @typeName(T), field.name });
+
+                                return error.InvalidFieldValue;
+                            }
+                        } else unreachable; // zig requires comptime fields to have a default initialization value
                     } else {
                         if (field_value) |fv| {
                             if (@typeInfo(field.field_type) == .Struct and @hasDecl(field.field_type, "__json_is_undefinedable"))
-                                @field(result, field.name) = .{ .value = try parseInternal(field.field_type.__json_T, @typeName(T), field.name, fv, options), .missing = false }
+                                @field(result, field.name) = .{
+                                    .value = try parseInternal(
+                                        field.field_type.__json_T,
+                                        name,
+                                        field.name,
+                                        fv,
+                                        maybe_allocator,
+                                        suppress_error_logs,
+                                    ),
+                                    .missing = false,
+                                }
                             else
-                                @field(result, field.name) = try parseInternal(field.field_type, @typeName(T), field.name, fv, options);
+                                @field(result, field.name) = try parseInternal(
+                                    field.field_type,
+                                    name,
+                                    field.name,
+                                    fv,
+                                    maybe_allocator,
+                                    suppress_error_logs,
+                                );
                         } else {
                             if (@typeInfo(field.field_type) == .Struct and @hasDecl(field.field_type, "__json_is_undefinedable")) {
                                 @field(result, field.name) = .{
@@ -237,9 +416,10 @@ fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime fi
                                     .missing = true,
                                 };
                             } else if (field.default_value) |default| {
-                                @field(result, field.name) = @ptrCast(*const field.field_type, default).*;
+                                const default_value = @ptrCast(*const field.field_type, default).*;
+                                @field(result, field.name) = default_value;
                             } else {
-                                if (!options.suppress_error_logs) logger.err("required field {s}.{s} missing, at {s}", .{ @typeName(T), field.name, name });
+                                if (comptime !suppress_error_logs) logger.debug("required field {s}.{s} missing, at {s}", .{ @typeName(T), field.name, name });
 
                                 missing_field = true;
                             }
@@ -251,39 +431,143 @@ fn parseInternal(comptime T: type, comptime parent_name: []const u8, comptime fi
 
                 return result;
             } else {
-                if (!options.suppress_error_logs) logger.err("expected Object, found {s} at {s}", .{ @tagName(value), name });
+                if (comptime !suppress_error_logs) logger.debug("expected Object, found {s} at {s}", .{ @tagName(json_value), name });
 
                 return error.UnexpectedFieldType;
             }
         },
         .Pointer => |info| {
-            switch (info.size) {
-                .Slice => {
-                    if (info.child == u8) {
-                        if (value == .String) {
-                            return value.String;
-                        } else {
-                            if (!options.suppress_error_logs) logger.err("expected String, found {s} at {s}", .{ @tagName(value), name });
-
-                            return error.UnexpectedFieldType;
-                        }
+            if (info.size == .Slice) {
+                if (info.child == u8) {
+                    if (json_value == .String) {
+                        return json_value.String;
                     } else {
-                        if (value == .Array) {
-                            if (info.child == std.json.Value) return value.Array.items;
+                        if (comptime !suppress_error_logs) logger.debug("expected String, found {s} at {s}", .{ @tagName(json_value), name });
 
-                            var array = try (options.allocator orelse return error.AllocatorRequired).alloc(info.child, value.Array.items.len);
-                            for (value.Array.items) |item, index|
-                                array[index] = try parseInternal(info.child, @typeName(T), "[...]", item, options);
+                        return error.UnexpectedFieldType;
+                    }
+                } else if (info.child == std.json.Value) {
+                    return json_value.Array.items;
+                }
+            }
 
-                            return array;
-                        } else {
-                            if (!options.suppress_error_logs) logger.err("expected Array, found {s} at {s}", .{ @tagName(value), name });
+            const allocator = maybe_allocator orelse return error.AllocatorRequired;
+            switch (info.size) {
+                .Slice, .Many => {
+                    const sentinel = if (info.sentinel) |ptr| @ptrCast(*const info.child, ptr).* else null;
 
-                            return error.UnexpectedFieldType;
-                        }
+                    if (info.child == u8 and json_value == .String) {
+                        const array = try allocator.allocWithOptions(
+                            info.child,
+                            json_value.String.len,
+                            info.alignment,
+                            sentinel,
+                        );
+
+                        std.mem.copy(u8, array, json_value.String);
+
+                        return @ptrCast(T, array);
+                    }
+
+                    if (json_value == .Array) {
+                        if (info.child == std.json.Value) return json_value.Array.items;
+
+                        const array = try allocator.allocWithOptions(
+                            info.child,
+                            json_value.Array.items.len,
+                            info.alignment,
+                            sentinel,
+                        );
+
+                        for (json_value.Array.items) |item, index|
+                            array[index] = try parseInternal(
+                                info.child,
+                                name,
+                                "[...]",
+                                item,
+                                maybe_allocator,
+                                suppress_error_logs,
+                            );
+
+                        return @ptrCast(T, array);
+                    } else {
+                        if (comptime !suppress_error_logs) logger.debug("expected Array, found {s} at {s}", .{ @tagName(json_value), name });
+
+                        return error.UnexpectedFieldType;
                     }
                 },
-                else => @compileError("unhandled pointer type: " ++ @typeName(T) ++ " at " ++ name),
+                .One, .C => {
+                    const data = try allocator.allocAdvanced(info.child, info.alignment, 1, .exact);
+
+                    data[0] = try parseInternal(
+                        info.child,
+                        name,
+                        "*",
+                        json_value,
+                        maybe_allocator,
+                        suppress_error_logs,
+                    );
+
+                    return &data[0];
+                },
+            }
+        },
+        .Array => |info| {
+            if (json_value == .Array) {
+                var array: T = undefined;
+
+                if (info.sentinel) |ptr| {
+                    const sentinel = @ptrCast(*const info.child, ptr).*;
+
+                    array[array.len] = sentinel;
+                }
+
+                if (json_value.Array.items.len != info.len) {
+                    if (comptime !suppress_error_logs) logger.debug("expected Array to match length of {s} but it doesn't; at {s}", .{ @typeName(T), name });
+                    return error.UnexpectedFieldType;
+                }
+
+                for (array) |*item, index|
+                    item.* = try parseInternal(
+                        info.child,
+                        name,
+                        "[...]",
+                        json_value.Array.items[index],
+                        maybe_allocator,
+                        suppress_error_logs,
+                    );
+
+                return array;
+            } else {
+                if (comptime !suppress_error_logs) logger.debug("expected Array, found {s} at {s}", .{ @tagName(json_value), name });
+
+                return error.UnexpectedFieldType;
+            }
+        },
+        .Vector => |info| {
+            if (json_value == .Array) {
+                var vector: T = undefined;
+
+                if (json_value.Array.items.len != info.len) {
+                    if (comptime !suppress_error_logs) logger.debug("expected Array to match length of {s} ({d}) but it doesn't; at {s}", .{ @typeName(T), info.len, name });
+                    return error.UnexpectedFieldType;
+                }
+
+                for (vector) |*item|
+                    item.* = try parseInternal(
+                        info.child,
+                        name,
+                        "[...]",
+                        item,
+                        maybe_allocator,
+                        suppress_error_logs,
+                    );
+
+                return vector;
+            } else {
+                if (comptime !suppress_error_logs) logger.debug("expected Array, found {s} at {s}", .{ @tagName(json_value), name });
+
+                return error.UnexpectedFieldType;
             }
         },
         else => {
@@ -330,10 +614,13 @@ test "json.parse simple struct" {
 
         random_map: std.json.ObjectMap,
         number_map: std.StringArrayHashMap(i64),
-        players: std.StringArrayHashMap(Player),
+        players: std.StringHashMap(Player),
 
         my_tuple: MyTuple,
-        // my_array: [2]u8,
+        my_array: [2]u8,
+
+        a_pointer: *u8,
+        a_weird_string: [*:0]u8,
     };
 
     const json =
@@ -364,7 +651,10 @@ test "json.parse simple struct" {
         \\        "aurame": {"name": "Auguste", "based": true},
         \\        "mattnite": {"name": "Matt", "based": true}
         \\    },
-        \\    "my_tuple": [10, false]
+        \\    "my_tuple": [10, false],
+        \\    "my_array": [1, 255],
+        \\    "a_pointer": 5,
+        \\    "a_weird_string": "hello"
         \\}
     ;
 
@@ -375,7 +665,7 @@ test "json.parse simple struct" {
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
     const tree = try testing_parser.parse(json);
 
-    const parsed = try parse(Struct, tree.root, .{ .allocator = arena.allocator() });
+    const parsed = try parse(Struct, tree.root, arena.allocator());
 
     try std.testing.expectEqual(true, parsed.bool_true);
     try std.testing.expectEqual(false, parsed.bool_false);
@@ -410,6 +700,12 @@ test "json.parse simple struct" {
     try std.testing.expectEqual(true, parsed.players.get("mattnite").?.based);
 
     try std.testing.expectEqual(MyTuple{ 10, false }, parsed.my_tuple);
+
+    try std.testing.expectEqual([2]u8{ 1, 255 }, parsed.my_array);
+
+    try std.testing.expectEqual(@as(u8, 5), parsed.a_pointer.*);
+
+    try std.testing.expectEqualStrings("hello", std.mem.sliceTo(parsed.a_weird_string, 0));
 }
 
 test "json.parse missing field" {
@@ -427,7 +723,7 @@ test "json.parse missing field" {
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
     const tree = try testing_parser.parse(json);
 
-    const parsed = parse(Struct, tree.root, .{ .allocator = arena.allocator() });
+    const parsed = parse(Struct, tree.root, arena.allocator());
 
     try std.testing.expectError(error.MissingRequiredField, parsed);
 }
@@ -451,7 +747,7 @@ test "json.parse undefinedable fields and default values" {
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
     const tree = try testing_parser.parse(json);
 
-    const parsed = try parse(Struct, tree.root, .{ .allocator = arena.allocator() });
+    const parsed = try parse(Struct, tree.root, arena.allocator());
 
     try std.testing.expectEqual(@as(i64, 42069), parsed.meh.value);
     try std.testing.expectEqual(true, parsed.meh2.missing);
@@ -494,14 +790,14 @@ test "json.parse comptime fields" {
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
 
     const first_tree = try testing_parser.parse(first_message);
-    const first_parsed = try parse(Message, first_tree.root, .{ .allocator = arena.allocator() });
+    const first_parsed = try parse(Message, first_tree.root, arena.allocator());
 
     try std.testing.expect(first_parsed == .youre_the_impostor);
 
     testing_parser.reset();
 
     const second_tree = try testing_parser.parse(second_message);
-    const second_parsed = try parse(Message, second_tree.root, .{ .allocator = arena.allocator() });
+    const second_parsed = try parse(Message, second_tree.root, arena.allocator());
 
     try std.testing.expect(second_parsed == .youre_cute_uwu);
 }
@@ -544,18 +840,18 @@ test "json.parse custom check functions for unions" {
             return err;
         }
 
-        pub fn tresParse(value: std.json.Value, options: ParseOptions) RequestOrNotificationParseError()!Self {
+        pub fn tresParse(value: std.json.Value, allocator: ?std.mem.Allocator) RequestOrNotificationParseError()!Self {
             // var allocator = options.allocator orelse return error.AllocatorRequired;
             var object = value.Object;
             var request_or_notif: Self = undefined;
 
             request_or_notif.jsonrpc = object.get("jsonrpc").?.String;
-            request_or_notif.id = if (object.get("id")) |id| try parse(RequestId, id, options) else null;
+            request_or_notif.id = if (object.get("id")) |id| try parse(RequestId, id, allocator) else null;
             request_or_notif.method = object.get("method").?.String;
 
             inline for (std.meta.fields(RequestParams)) |field| {
                 if (std.mem.eql(u8, request_or_notif.method, field.field_type.method)) {
-                    request_or_notif.params = @unionInit(RequestParams, field.name, try parse(field.field_type, object.get("params").?, options));
+                    request_or_notif.params = @unionInit(RequestParams, field.name, try parse(field.field_type, object.get("params").?, allocator));
                 }
             }
 
@@ -577,7 +873,7 @@ test "json.parse custom check functions for unions" {
 
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
     const first_tree = try testing_parser.parse(first_message);
-    const first_parsed = try parse(RequestOrNotification, first_tree.root, .{ .allocator = arena.allocator() });
+    const first_parsed = try parse(RequestOrNotification, first_tree.root, arena.allocator());
 
     try std.testing.expectEqualStrings("2.0", first_parsed.jsonrpc);
     try std.testing.expect(first_parsed.id != null);
@@ -596,9 +892,9 @@ test "json.parse allocator required errors" {
 
     var testing_parser = std.json.Parser.init(arena.allocator(), false);
 
-    try std.testing.expectError(error.AllocatorRequired, parse([]i64, (try testing_parser.parse("[1, 2, 3, 4]")).root, .{}));
+    try std.testing.expectError(error.AllocatorRequired, parse([]i64, (try testing_parser.parse("[1, 2, 3, 4]")).root, null));
     testing_parser.reset();
     try std.testing.expectError(error.AllocatorRequired, parse(std.StringArrayHashMap(i64), (try testing_parser.parse(
         \\{"a": 123, "b": -69}
-    )).root, .{}));
+    )).root, null));
 }


### PR DESCRIPTION
Gets rid of ParseOptions in favor of using logger.debug and a comptime argument to omit logging in release builds.

Adds support for Vectors, Arrays, and all Pointers.

Tidy up code related to determining when we need an allocator