### PR TITLE
add missing return keyword

### DIFF
--- a/tres.zig
+++ b/tres.zig
@@ -921,7 +921,7 @@ pub fn stringify(
             const array: [info.len]info.child = value;
             return stringify(&array, options, out_stream);
         },
-        .Void => try out_stream.writeAll("{}"),
+        .Void => return try out_stream.writeAll("{}"),
         else => @compileError("Unable to stringify type '" ++ @typeName(T) ++ "'"),
     }
     unreachable;

--- a/tres.zig
+++ b/tres.zig
@@ -781,6 +781,7 @@ pub fn stringify(
                         return try stringify(@field(value, u_field.name), options, out_stream);
                     }
                 }
+                return;
             } else {
                 @compileError("Unable to stringify untagged union '" ++ @typeName(T) ++ "'");
             }


### PR DESCRIPTION
without it you would hit `unreachable` when stringifying void or a union