### PR TITLE
remove duplicate line break when stringifying slices

### DIFF
--- a/tres.zig
+++ b/tres.zig
@@ -954,7 +954,6 @@ pub fn stringify(
                 }
                 if (value.len != 0) {
                     if (options.whitespace) |whitespace| {
-                        try out_stream.writeByte('\n');
                         try whitespace.outputIndent(out_stream);
                     }
                 }

--- a/tres.zig
+++ b/tres.zig
@@ -948,7 +948,6 @@ pub fn stringify(
                         try out_stream.writeByte(',');
                     }
                     if (child_options.whitespace) |child_whitespace| {
-                        try out_stream.writeByte('\n');
                         try child_whitespace.outputIndent(out_stream);
                     }
                     try stringify(x, child_options, out_stream);


### PR DESCRIPTION
turns
```json
{
    "enum": [

        "off",

        "message",

        "verbose"

    ]
}
```
into
```json
{
    "enum": [
        "off",
        "message",
        "verbose"
    ],
}
```
for some reason i wrote stringifying arrays instead of slices in the commit message. 